### PR TITLE
Update sensor.py / add tag Temperature Water Setpoint

### DIFF
--- a/custom_components/waterkotte_heatpump/sensor.py
+++ b/custom_components/waterkotte_heatpump/sensor.py
@@ -214,6 +214,16 @@ SENSOR_TYPES = {
         None,
         None,
     ],
+     "temperature_water_setpoint": [
+        "Temperature Water Setpoint",
+        EcotouchTag.TEMPERATURE_WATER_SETPOINT,
+        DEVICE_CLASS_TEMPERATURE,
+        TEMP_CELSIUS,
+        "mdi:snowflake-thermometer",
+        True,
+        None,
+        None,
+     ],
     "temperature_pool": [
         "Temperature Pool",
         EcotouchTag.TEMPERATURE_POOL,


### PR DESCRIPTION
I have added the tag "temperature water setpoint". This displays the current Setpoint/requirement temperature for Warmwater. Relevant especially if you use the +/- offset for certain times. I have implemented it in my local HA installation which is based off your 0.11 integration. Works as intended.